### PR TITLE
Fix small typo in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Installation
             "dramatiq.middleware.TimeLimit",
             "dramatiq.middleware.Callbacks",
             "dramatiq.middleware.Retries",
-        },
+        ],
     }
 
 4. Start the worker process:


### PR DESCRIPTION
I think that this should be a `]`, so I figured I'd send a PR instead of an issue. :heart: